### PR TITLE
feat: add React-based registration on Blade home page

### DIFF
--- a/laravel-react/app/Http/Controllers/AuthController.php
+++ b/laravel-react/app/Http/Controllers/AuthController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+
+class AuthController extends Controller
+{
+    public function register(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users',
+            'password' => 'required|min:8|confirmed',
+        ]);
+
+        $user = User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => Hash::make($data['password']),
+        ]);
+
+        return response()->json([
+            'message' => 'ثبت نام با موفقیت انجام شد.',
+            'user' => $user,
+        ]);
+    }
+}

--- a/laravel-react/app/Http/Controllers/HomeController.php
+++ b/laravel-react/app/Http/Controllers/HomeController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class HomeController extends Controller
+{
+    public function index()
+    {
+        return view('home');
+    }
+}

--- a/laravel-react/resources/js/register.jsx
+++ b/laravel-react/resources/js/register.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { createRoot } from 'react-dom/client';
+
+function RegisterForm({ routeRegister }) {
+    const [form, setForm] = useState({
+        name: '',
+        email: '',
+        password: '',
+        password_confirmation: '',
+    });
+    const [msg, setMsg] = useState('');
+
+    const handleChange = (e) => {
+        setForm({ ...form, [e.target.name]: e.target.value });
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setMsg('');
+
+        const res = await fetch(routeRegister, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+            },
+            body: JSON.stringify(form),
+        });
+
+        const data = await res.json();
+        setMsg(data.message || 'خطا در ثبت نام');
+    };
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <input name="name" placeholder="نام" value={form.name} onChange={handleChange} />
+            <input name="email" placeholder="ایمیل" value={form.email} onChange={handleChange} />
+            <input type="password" name="password" placeholder="رمز عبور" value={form.password} onChange={handleChange} />
+            <input
+                type="password"
+                name="password_confirmation"
+                placeholder="تکرار رمز عبور"
+                value={form.password_confirmation}
+                onChange={handleChange}
+            />
+            <button type="submit">ثبت نام</button>
+            {msg && <p>{msg}</p>}
+        </form>
+    );
+}
+
+const container = document.getElementById('register-root');
+const routeRegister = container.dataset.routeRegister;
+createRoot(container).render(<RegisterForm routeRegister={routeRegister} />);

--- a/laravel-react/resources/views/home.blade.php
+++ b/laravel-react/resources/views/home.blade.php
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="fa">
+<head>
+    <meta charset="UTF-8">
+    <title>صفحه اصلی</title>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    @viteReactRefresh
+    @vite('resources/js/register.jsx')
+</head>
+<body>
+    <h1>خوش آمدید</h1>
+
+    <div id="register-root" data-route-register="{{ route('register') }}"></div>
+</body>
+</html>

--- a/laravel-react/routes/web.php
+++ b/laravel-react/routes/web.php
@@ -1,12 +1,13 @@
 <?php
 
+use App\Http\Controllers\AuthController;
+use App\Http\Controllers\HomeController;
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::get('/', [HomeController::class, 'index'])->name('home');
+Route::post('/register', [AuthController::class, 'register'])->name('register');
 
 Route::get('/dashboard', function () {
     return Inertia::render('Dashboard');


### PR DESCRIPTION
## Summary
- add HomeController and AuthController for root and registration
- render home view via Blade with React registration form
- implement register.jsx React component

## Testing
- `npm test` (fails: Missing script "test")
- `composer test` (fails: Tests: 24 failed, MissingAppKeyException)


------
https://chatgpt.com/codex/tasks/task_b_68a84955e7e483268d51f3b99f819d69